### PR TITLE
Use standard blind schnorr signatures (no pubkey tweak)

### DIFF
--- a/schnorr_fun/src/blind.rs
+++ b/schnorr_fun/src/blind.rs
@@ -30,7 +30,7 @@
 //!
 //! # Synopsis
 //! ```
-//! use schnorr_fun::{blind, Blinder, Message, Schnorr, nonce};
+//! use schnorr_fun::{blind, Message, Schnorr, nonce};
 //! use secp256kfun::{g, marker::Public, Scalar, G, derive_nonce, nonce::Deterministic};
 //! use rand::rngs::ThreadRng;
 //! use sha2::Sha256;
@@ -70,7 +70,7 @@
 //! let blind_sessions: Vec<_> = pub_nonces
 //!     .iter()
 //!     .map(|pub_nonce| {
-//!         Blinder::blind(
+//!         blind::Blinder::blind(
 //!             *pub_nonce,
 //!             public_key,
 //!             message,

--- a/schnorr_fun/src/lib.rs
+++ b/schnorr_fun/src/lib.rs
@@ -28,10 +28,10 @@ pub mod binonce;
 #[cfg(feature = "alloc")]
 pub mod musig;
 
+#[cfg(feature = "alloc")]
 pub mod blind;
 #[cfg(feature = "alloc")]
 pub mod frost;
-pub use blind::*;
 
 mod signature;
 pub use signature::Signature;


### PR DESCRIPTION
Exploring changes to https://github.com/LLFourn/secp256kfun/pull/98 such that these signatures follow the more standard scheme.

TODO
* Check what none grinding is still necessary for Even-Y points 
* Find some sources for the scheme
* Check the statements regarding (sig, nonce) correlation in docs are still true 